### PR TITLE
feat: add libyaml-dev and btop to system dependencies

### DIFF
--- a/roles/qtile-wm/tasks/main.yml
+++ b/roles/qtile-wm/tasks/main.yml
@@ -52,6 +52,7 @@
       - arandr  # GUI for monitor configuration
       - autorandr  # Automatic monitor configuration switching
       - adwaita-icon-theme  # Includes Adwaita cursor theme
+      - btop  # Modern system resource monitor
     state: present
   ignore_errors: yes  # Some packages might not be available on all systems
 

--- a/roles/system-deps/defaults/main.yml
+++ b/roles/system-deps/defaults/main.yml
@@ -29,6 +29,7 @@ system_packages:
   # Development libraries
   - libssl-dev
   - libffi-dev
+  - libyaml-dev
   - libreadline-dev
   - libsqlite3-dev
   - libbz2-dev


### PR DESCRIPTION
Add libyaml-dev to development libraries for YAML parsing support and btop as a modern system resource monitor in the qtile desktop environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
