### PR TITLE
feat: add PostgreSQL client tools and libpq-dev to system dependencies

### DIFF
--- a/roles/system-deps/defaults/main.yml
+++ b/roles/system-deps/defaults/main.yml
@@ -34,14 +34,19 @@ system_packages:
   - libsqlite3-dev
   - libbz2-dev
   - zlib1g-dev
-  
+  - libpq-dev
+
   # Python3 system packages (no compilation)
   - python3
   - python3-dev
   - python3-pip
   - python3-venv
   - python3-virtualenv
-  
+
+  # PostgreSQL client tools
+  - postgresql-client
+  - postgresql-contrib
+
   # Utilities
   - sqlite3
   - tcl


### PR DESCRIPTION
## Summary
- Add `postgresql-client` and `postgresql-contrib` packages for PostgreSQL command-line tools
- Add `libpq-dev` development headers for building PostgreSQL client applications

## Test plan
- [ ] Run `ansible-playbook --ask-become-pass playbooks/base-environment.yml`
- [ ] Verify packages install successfully
- [ ] Test PostgreSQL client tools availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)