### PR TITLE
feat: server hardening, deprecation fixes, and headless server support

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ roles_path = roles
 host_key_checking = False
 retry_files_enabled = False
 nocows = 1
+interpreter_python = auto_silent

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+# Distributed Dotfiles - Task Runner
+
+# Setup a headless Linux server
+setup-linux-server host user:
+    ansible-playbook --ask-become-pass -i {{ host }}, -u {{ user }} playbooks/base-environment.yml

--- a/playbooks/base-environment.yml
+++ b/playbooks/base-environment.yml
@@ -14,7 +14,7 @@
       apt:
         update_cache: yes
         cache_valid_time: 86400
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
       
     - name: Check which packages are missing
       shell: dpkg -l {{ item }} 2>/dev/null | grep -q '^ii' || echo "{{ item }}"
@@ -36,12 +36,12 @@
         - rsync
       changed_when: false
       failed_when: false
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
 
     - name: Create list of packages to install
       set_fact:
         packages_to_install: "{{ missing_packages_check.results | selectattr('stdout', 'defined') | selectattr('stdout', '!=', '') | map(attribute='stdout') | list }}"
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
 
     - name: Install missing system packages
       apt:
@@ -50,7 +50,7 @@
         install_recommends: no
         force_apt_get: yes
       when: 
-        - ansible_os_family == "Debian"
+        - ansible_facts["os_family"] == "Debian"
         - packages_to_install is defined
         - packages_to_install | length > 0
 
@@ -72,6 +72,10 @@
       tags: [shell, rust, languages]
     - role: fish-config
       tags: [shell, fish, config]
+
+    # Server Hardening (Debian/Ubuntu only)
+    - role: server-hardening
+      tags: [server, security, hardening]
 
     # Development Environment
     - role: system-deps

--- a/playbooks/deprecated/devex/neovim.yml
+++ b/playbooks/deprecated/devex/neovim.yml
@@ -17,15 +17,15 @@
     - name: Checkout astronvim
       git:
         repo: 'https://github.com/AstroNvim/AstroNvim'
-        dest: '{{ansible_env.HOME}}/.config/nvim'
+        dest: '{{ansible_facts.env.HOME}}/.config/nvim'
         update: yes
     - name: Checkout My personal neovim config
       git:
         repo: 'https://github.com/stonecharioteer/dotfiles-astronvim'
-        dest: '{{ansible_env.HOME}}/code/tools/dotfiles/astronvim'
+        dest: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/astronvim'
         update: yes
     - name: Symlink the user config into the astronvim folder
       file:
-        src: '{{ansible_env.HOME}}/code/tools/dotfiles/astronvim/user'
-        dest: '{{ansible_env.HOME}}/.config/nvim/lua/user'
+        src: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/astronvim/user'
+        dest: '{{ansible_facts.env.HOME}}/.config/nvim/lua/user'
         state: link

--- a/playbooks/deprecated/devex/shell.yml
+++ b/playbooks/deprecated/devex/shell.yml
@@ -18,7 +18,7 @@
         - name: Make fish the default shell
           shell:
             cmd: |
-              usermod --shell /usr/bin/fish {{ansible_env.USER}}
+              usermod --shell /usr/bin/fish {{ansible_facts.env.USER}}
     - name: Install Star Ship Prompt
       block:
         - name: Download Starship Installer

--- a/playbooks/deprecated/devex/tmux.yml
+++ b/playbooks/deprecated/devex/tmux.yml
@@ -31,25 +31,25 @@
     - name: Download gpakosz's tmux config
       git:
         repo: https://github.com/gpakosz/.tmux
-        dest: '{{ansible_env.HOME}}/code/tools/.tmux'
+        dest: '{{ansible_facts.env.HOME}}/code/tools/.tmux'
         update: yes
     - name: Symlink tmux config folder to home directory
       file:
-        src: '{{ansible_env.HOME}}/code/tools/.tmux'
-        dest: '{{ansible_env.HOME}}/.tmux'
+        src: '{{ansible_facts.env.HOME}}/code/tools/.tmux'
+        dest: '{{ansible_facts.env.HOME}}/.tmux'
         state: link
     - name: Symlink tmux config file to home directory
       file:
-        src: '{{ansible_env.HOME}}/code/tools/.tmux/.tmux.conf'
-        dest: '{{ansible_env.HOME}}/.tmux.conf'
+        src: '{{ansible_facts.env.HOME}}/code/tools/.tmux/.tmux.conf'
+        dest: '{{ansible_facts.env.HOME}}/.tmux.conf'
         state: link
     - name: Download my local tmux config
       git:
         repo: https://github.com/stonecharioteer/dotfiles-tmux
-        dest: '{{ansible_env.HOME}}/code/tools/dotfiles/tmux'
+        dest: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/tmux'
         update: yes
     - name: Symlink my local tmux config file
       file:
-        src: '{{ansible_env.HOME}}/code/tools/dotfiles/tmux/.tmux.conf.local'
-        dest: '{{ansible_env.HOME}}/.tmux.conf.local'
+        src: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/tmux/.tmux.conf.local'
+        dest: '{{ansible_facts.env.HOME}}/.tmux.conf.local'
         state: link

--- a/playbooks/deprecated/nvim.yml
+++ b/playbooks/deprecated/nvim.yml
@@ -4,13 +4,13 @@
     # only do this if nvim isn't installed
     - name: Delete nvim archive if present
       file:
-        path: "{{ ansible_env.HOME }}/nvim.tar.gz"
+        path: "{{ ansible_facts.env.HOME }}/nvim.tar.gz"
         state: absent
       when: reinstall
     - name: Download neovim 0.6.1
       get_url: 
         url: https://github.com/neovim/neovim/releases/download/v0.6.1/nvim-linux64.tar.gz
-        dest: "{{ansible_env.HOME}}/nvim.tar.gz"
+        dest: "{{ansible_facts.env.HOME}}/nvim.tar.gz"
         checksum: sha256:06f1c19b09dd8cc63f970ef7edab8fa3850a154c296f453393d00854f514a847
       when: reinstall
     - name: Delete nvim folder
@@ -24,14 +24,14 @@
     - name: Unpack neovim
       become: yes
       unarchive:
-        src: "{{ansible_env.HOME}}/nvim.tar.gz"
+        src: "{{ansible_facts.env.HOME}}/nvim.tar.gz"
         dest: /opt/
         remote_src: yes
         mode: a+rx,g-w,o-w
       when: reinstall
     - name: Delete nvim archive
       file:
-        path: "{{ ansible_env.HOME }}/nvim.tar.gz"
+        path: "{{ ansible_facts.env.HOME }}/nvim.tar.gz"
         state: absent
       when: reinstall
       tags:
@@ -57,7 +57,7 @@
     - name: Download neovim Config
       git:
         repo: "https://github.com/stonecharioter/dotfiles-nvim"
-        dest: "{{ ansible_env.HOME}}/.config/nvim"
+        dest: "{{ ansible_facts.env.HOME}}/.config/nvim"
         accept_hostkey: yes
         version: master
         update: yes

--- a/playbooks/deprecated/python-setup.yml
+++ b/playbooks/deprecated/python-setup.yml
@@ -18,7 +18,7 @@
             validate_certs: no
             repo: "ppa:deadsnakes"
             state: present
-          when: ansible_distribution_major_version|int >= 18 and ansible_distribution_major_version|int < 21
+          when: ansible_facts["distribution_major_version"]|int >= 18 and ansible_facts["distribution_major_version"]|int < 21
           register: add_deadsnakes
           tags:
             - python
@@ -34,7 +34,7 @@
             # TODO: I need to also add the public key https://ubuntuforums.org/showthread.php?t=1263676
             content: |
               deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu/ focal main
-          when: ansible_distribution_major_version|int == 21
+          when: ansible_facts["distribution_major_version"]|int == 21
           tags:
             - python
             - python3.8
@@ -45,7 +45,7 @@
             - deadsnakes
         - name: Add the public key for the deadsnakes ppa
           command: apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776 
-          when:  ansible_distribution_major_version|int == 21
+          when:  ansible_facts["distribution_major_version"]|int == 21
           tags:
             - python
             - python3.8
@@ -107,7 +107,7 @@
             - python
             - python3.8
             - ubuntu
-          when: ansible_distribution_major_version|int == 18
+          when: ansible_facts["distribution_major_version"]|int == 18
         - name: Check if libmpdec2 has been installed (for Python 3.9)
           command: dpkg-query -W libmpdec2
           register: libmpdec2_installed
@@ -129,20 +129,20 @@
         - name: Download libmpdec2.deb
           get_url:
             url="http://archive.ubuntu.com/ubuntu/pool/main/m/mpdecimal/libmpdec2_2.4.2-3_amd64.deb"
-            dest="{{ ansible_env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
+            dest="{{ ansible_facts.env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
           when: libmpdec2_installed.rc == 1
           tags:
             - python3.9
             - libmpdec2
         - name: Install libmpdec2 from deb file (for Python 3.9)
-          apt: deb="{{ ansible_env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
+          apt: deb="{{ ansible_facts.env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
           when: libmpdec2_installed.rc == 1
           tags:
             - python3.9
             - libmpdec2
         - name: Remove libmpdec2 installation file (for Python 3.9)
           file:
-            path: "{{ ansible_env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
+            path: "{{ ansible_facts.env.HOME }}/libmpdec2_2.4.2-3_amd64.deb"
             state: absent
           tags:
             - python3.9
@@ -182,5 +182,5 @@
             - ubuntu
     - name: Setup virtual environments folders
       file:
-        path: "{{ ansible_env.HOME }}/.venvs"
+        path: "{{ ansible_facts.env.HOME }}/.venvs"
         state: directory

--- a/playbooks/gui-environment.yml
+++ b/playbooks/gui-environment.yml
@@ -14,7 +14,7 @@
       apt:
         update_cache: yes
         cache_valid_time: 86400
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
       
     - name: Check which packages are missing
       shell: dpkg -l {{ item }} 2>/dev/null | grep -q '^ii' || echo "{{ item }}"
@@ -40,12 +40,12 @@
         - rsync
       changed_when: false
       failed_when: false
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
 
     - name: Create list of packages to install
       set_fact:
         packages_to_install: "{{ missing_packages_check.results | selectattr('stdout', 'defined') | selectattr('stdout', '!=', '') | map(attribute='stdout') | list }}"
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
 
     - name: Install missing system packages for GUI workstation
       apt:
@@ -54,7 +54,7 @@
         install_recommends: no
         force_apt_get: yes
       when: 
-        - ansible_os_family == "Debian"
+        - ansible_facts["os_family"] == "Debian"
         - packages_to_install is defined
         - packages_to_install | length > 0
 

--- a/playbooks/macos-base-environment.yml
+++ b/playbooks/macos-base-environment.yml
@@ -6,15 +6,15 @@
   gather_facts: true
   vars:
     dev_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
-    dev_home: "{{ ansible_env.HOME | default('/Users/' + dev_user) }}"
+    dev_home: "{{ ansible_facts.env.HOME | default('/Users/' + dev_user) }}"
 
   pre_tasks:
     - name: Verify running on macOS
       assert:
         that:
-          - ansible_os_family == "Darwin"
+          - ansible_facts["os_family"] == "Darwin"
         fail_msg: "This playbook is designed for macOS only"
-        success_msg: "✓ Running on macOS {{ ansible_distribution_version }}"
+        success_msg: "✓ Running on macOS {{ ansible_facts['distribution_version'] }}"
 
     - name: Verify pbcopy is available (built-in on macOS)
       command: which pbcopy

--- a/playbooks/macos-gui-environment.yml
+++ b/playbooks/macos-gui-environment.yml
@@ -6,15 +6,15 @@
   gather_facts: true
   vars:
     dev_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
-    dev_home: "{{ ansible_env.HOME | default('/Users/' + dev_user) }}"
+    dev_home: "{{ ansible_facts.env.HOME | default('/Users/' + dev_user) }}"
 
   pre_tasks:
     - name: Verify running on macOS
       assert:
         that:
-          - ansible_os_family == "Darwin"
+          - ansible_facts["os_family"] == "Darwin"
         fail_msg: "This playbook is designed for macOS only"
-        success_msg: "✓ Running on macOS {{ ansible_distribution_version }}"
+        success_msg: "✓ Running on macOS {{ ansible_facts['distribution_version'] }}"
 
     - name: Verify pbcopy is available (built-in on macOS)
       command: which pbcopy

--- a/playbooks/tasks/dev-folders.yml
+++ b/playbooks/tasks/dev-folders.yml
@@ -5,25 +5,25 @@
   block:
     - name: Create $HOME/code
       file:
-        path: "{{ansible_env.HOME}}/code"
+        path: "{{ansible_facts.env.HOME}}/code"
         state: directory
     - name: Create $HOME/code/checkouts
       file:
-        path: "{{ansible_env.HOME}}/code/checkouts"
+        path: "{{ansible_facts.env.HOME}}/code/checkouts"
         state: directory
     - name: Create $HOME/code/checkouts/personal
       file:
-        path: "{{ansible_env.HOME}}/code/checkouts/personal"
+        path: "{{ansible_facts.env.HOME}}/code/checkouts/personal"
         state: directory
     - name: Create $HOME/code/checkouts/work
       file:
-        path: "{{ansible_env.HOME}}/code/checkouts/work"
+        path: "{{ansible_facts.env.HOME}}/code/checkouts/work"
         state: directory
     - name: Create $HOME/code/tools/
       file:
-        path: "{{ansible_env.HOME}}/code/tools"
+        path: "{{ansible_facts.env.HOME}}/code/tools"
         state: directory
     - name: Create $HOME/code/tools/dotfiles/
       file:
-        path: "{{ansible_env.HOME}}/code/tools/dotfiles/"
+        path: "{{ansible_facts.env.HOME}}/code/tools/dotfiles/"
         state: directory

--- a/playbooks/tasks/docker.yml
+++ b/playbooks/tasks/docker.yml
@@ -22,7 +22,7 @@
         state: present
     - name: Add Docker respository
       apt_repository:
-        repo: 'deb https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable'
+        repo: 'deb https://download.docker.com/linux/ubuntu {{ ansible_facts["distribution_release"] }} stable'
         state: present
     - name: Install docker engine, containerd and Docker Compose
       apt:
@@ -37,8 +37,8 @@
       group:
         name: docker
         state: present
-    - name: Add '{{ansible_env.USER }}' to `docker` group
+    - name: Add '{{ansible_facts.env.USER }}' to `docker` group
       user:
-        name: '{{ansible_env.USER }}'
+        name: '{{ansible_facts.env.USER }}'
         groups: docker
         append: yes

--- a/playbooks/tasks/fish.yml
+++ b/playbooks/tasks/fish.yml
@@ -18,12 +18,12 @@
             pkg: fish
         - name: Set fish as the user's default shell.
           user:
-            name: '{{ansible_env.USER}}'
+            name: '{{ansible_facts.env.USER}}'
             shell: /usr/bin/fish
     - name: Download my personal fish config and symlink it to the config folder
       shell:
         cmd: |
-          if [ -L '{{ansible_env.HOME}}/code/tools/dotfiles/fish' ]; then 
-            git clone 'git@github.com:stonecharioteer/dotfiles-fish' '{{ansible_env.HOME}}/code/tools/dotfiles/fish'
+          if [ -L '{{ansible_facts.env.HOME}}/code/tools/dotfiles/fish' ]; then 
+            git clone 'git@github.com:stonecharioteer/dotfiles-fish' '{{ansible_facts.env.HOME}}/code/tools/dotfiles/fish'
           fi
-          rm -rf '{{ansible_env.HOME}}/.config/fish' && ln -s '{{ansible_env.HOME}}/code/tools/dotfiles/fish/fish' '{{ansible_env.HOME}}/.config/fish'
+          rm -rf '{{ansible_facts.env.HOME}}/.config/fish' && ln -s '{{ansible_facts.env.HOME}}/code/tools/dotfiles/fish/fish' '{{ansible_facts.env.HOME}}/.config/fish'

--- a/playbooks/tasks/gui-fonts.yml
+++ b/playbooks/tasks/gui-fonts.yml
@@ -10,7 +10,7 @@
       # https://www.nerdfonts.com/font-downloads
       wget https://github.com/ryanoasis/nerd-fonts/releases/download/v2.2.2/JetBrainsMono.zip
       unzip -o JetBrainsMono.zip
-      mkdir -p '{{ansible_env.HOME}}/.local/share/fonts/fonts/ttf'
-      mv JetBrains*.ttf '{{ansible_env.HOME}}/.local/share/fonts/fonts/ttf'
+      mkdir -p '{{ansible_facts.env.HOME}}/.local/share/fonts/fonts/ttf'
+      mv JetBrains*.ttf '{{ansible_facts.env.HOME}}/.local/share/fonts/fonts/ttf'
       fc-cache -fv
     chdir: /tmp

--- a/playbooks/tasks/neovim.yml
+++ b/playbooks/tasks/neovim.yml
@@ -15,14 +15,14 @@
     - name: Checkout astronvim
       git:
         repo: 'https://github.com/AstroNvim/AstroNvim'
-        dest: '{{ansible_env.HOME}}/.config/nvim'
+        dest: '{{ansible_facts.env.HOME}}/.config/nvim'
         update: yes
     - name: Download my personal astronvim config and symlink it to the config folder
       # TODO: I need to use ssh to download these, but I can't do that if the
       # key is encrypted. I'm not sure how to do that.
       shell:
         cmd: |
-          if [ -L '{{ansible_env.HOME}}/code/tools/dotfiles/astronvim' ]; then 
-            git clone 'git@github.com:stonecharioteer/dotfiles-astronvim' '{{ansible_env.HOME}}/code/tools/dotfiles/astronvim'
+          if [ -L '{{ansible_facts.env.HOME}}/code/tools/dotfiles/astronvim' ]; then 
+            git clone 'git@github.com:stonecharioteer/dotfiles-astronvim' '{{ansible_facts.env.HOME}}/code/tools/dotfiles/astronvim'
           fi
-          rm -rf '{{ansible_env.HOME}}/.config/nvim/lua/user' && ln -s '{{ansible_env.HOME}}/code/tools/dotfiles/astronvim/user' '{{ansible_env.HOME}}/.config/nvim/lua/user'
+          rm -rf '{{ansible_facts.env.HOME}}/.config/nvim/lua/user' && ln -s '{{ansible_facts.env.HOME}}/code/tools/dotfiles/astronvim/user' '{{ansible_facts.env.HOME}}/.config/nvim/lua/user'

--- a/playbooks/tasks/python/3.9.yml
+++ b/playbooks/tasks/python/3.9.yml
@@ -6,22 +6,22 @@
   block:
     - name: Check if Python 3.9 is already installed
       stat:
-        path: '{{ansible_env.HOME}}/.python/py3.9/bin/python3'
+        path: '{{ansible_facts.env.HOME}}/.python/py3.9/bin/python3'
       register: python39
     - name: Create Python 3.9 directory
       when: not python39.stat.exists
       file:
-        path: '{{ansible_env.HOME}}/.python/py3.9/'
+        path: '{{ansible_facts.env.HOME}}/.python/py3.9/'
         state: directory
     - name: Install Python 3.9
       when: not python39.stat.exists
       shell:
         cmd: |
-          echo "Ansible processor vcpus = {{ansible_processor_vcpus}}"
+          echo "Ansible processor vcpus = {{ansible_facts["processor_vcpus"]}}"
           wget --quiet https://www.python.org/ftp/python/3.9.15/Python-3.9.15.tar.xz
           tar -xvf Python-3.9.15.tar.xz
           cd Python-3.9.15
-          ./configure --prefix='{{ansible_env.HOME}}/.python/py3.9/' --enable-optimizations
-          make -s -j'{{ansible_processor_vcpus}}'
+          ./configure --prefix='{{ansible_facts.env.HOME}}/.python/py3.9/' --enable-optimizations
+          make -s -j'{{ansible_facts["processor_vcpus"]}}'
           make altinstall
         chdir: /tmp

--- a/playbooks/tasks/qtile.yml
+++ b/playbooks/tasks/qtile.yml
@@ -24,7 +24,7 @@
           tar -xvf Python-3.9.15.tar.xz
           cd Python-3.9.15
           ./configure --prefix=/opt/qtile --enable-optimizations
-          make -s -j'{{ansible_processor_vcpus}}'
+          make -s -j'{{ansible_facts["processor_vcpus"]}}'
           make altinstall
         chdir: /tmp
     - name: Download and install the pystonecharioteer config.
@@ -49,26 +49,26 @@
           - xscreensaver
     - name: Create the qtile configuration folder
       file:
-        path: "{{ansible_env.HOME}}/.config/qtile/"
+        path: "{{ansible_facts.env.HOME}}/.config/qtile/"
         state: directory
     - name: Checkout the pystonecharioteer repo and link the config
       shell:
         cmd: |
-          if [o-L '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer' ]; then 
-            git clone 'git@github.com:stonecharioteer/pystonecharioteer.git' '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer'
+          if [o-L '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer' ]; then 
+            git clone 'git@github.com:stonecharioteer/pystonecharioteer.git' '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer'
           fi
-          rm -rf '{{ansible_env.HOME}}/.config/qtile/config.py'
-          ln -s '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer/config.py' '{{ansible_env.HOME}}/.config/qtile/config.py'
-          rm -rf '{{ansible_env.HOME}}/.config/qtile/stonecharioteer.json'
-          ln -s '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer/stonecharioteer.json' '{{ansible_env.HOME}}/.config/qtile/stonecharioteer.json'
-          rm -rf '{{ansible_env.HOME}}/.config/qtile/autostart.sh'
-          ln -s '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer/autostart.sh' '{{ansible_env.HOME}}/.config/qtile/autostart.sh'
+          rm -rf '{{ansible_facts.env.HOME}}/.config/qtile/config.py'
+          ln -s '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer/config.py' '{{ansible_facts.env.HOME}}/.config/qtile/config.py'
+          rm -rf '{{ansible_facts.env.HOME}}/.config/qtile/stonecharioteer.json'
+          ln -s '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer/stonecharioteer.json' '{{ansible_facts.env.HOME}}/.config/qtile/stonecharioteer.json'
+          rm -rf '{{ansible_facts.env.HOME}}/.config/qtile/autostart.sh'
+          ln -s '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer/autostart.sh' '{{ansible_facts.env.HOME}}/.config/qtile/autostart.sh'
       tags:
         - debug
     - name: Copy the qtile.desktop file
       become: true
       copy:
-        src: '{{ansible_env.HOME}}/code/checkouts/personal/pystonecharioteer/qtile.desktop'
+        src: '{{ansible_facts.env.HOME}}/code/checkouts/personal/pystonecharioteer/qtile.desktop'
         dest: '/usr/share/xsessions/qtile.desktop'
         remote_src: true
       tags:

--- a/playbooks/tasks/tmux.yml
+++ b/playbooks/tasks/tmux.yml
@@ -29,25 +29,25 @@
     - name: Download gpakosz's tmux config
       git:
         repo: https://github.com/gpakosz/.tmux
-        dest: '{{ansible_env.HOME}}/code/tools/.tmux'
+        dest: '{{ansible_facts.env.HOME}}/code/tools/.tmux'
         update: yes
     - name: Symlink tmux config folder to home directory
       file:
-        src: '{{ansible_env.HOME}}/code/tools/.tmux'
-        dest: '{{ansible_env.HOME}}/.tmux'
+        src: '{{ansible_facts.env.HOME}}/code/tools/.tmux'
+        dest: '{{ansible_facts.env.HOME}}/.tmux'
         state: link
     - name: Symlink tmux config file to home directory
       file:
-        src: '{{ansible_env.HOME}}/code/tools/.tmux/.tmux.conf'
-        dest: '{{ansible_env.HOME}}/.tmux.conf'
+        src: '{{ansible_facts.env.HOME}}/code/tools/.tmux/.tmux.conf'
+        dest: '{{ansible_facts.env.HOME}}/.tmux.conf'
         state: link
     - name: Download my local tmux config
       git:
         repo: 'https://github.com/stonecharioteer/dotfiles-tmux'
-        dest: '{{ansible_env.HOME}}/code/tools/dotfiles/tmux'
+        dest: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/tmux'
         update: yes
     - name: Symlink my local tmux config file
       file:
-        src: '{{ansible_env.HOME}}/code/tools/dotfiles/tmux/.tmux.conf.local'
-        dest: '{{ansible_env.HOME}}/.tmux.conf.local'
+        src: '{{ansible_facts.env.HOME}}/code/tools/dotfiles/tmux/.tmux.conf.local'
+        dest: '{{ansible_facts.env.HOME}}/.tmux.conf.local'
         state: link

--- a/roles/aerospace-wm/defaults/main.yml
+++ b/roles/aerospace-wm/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Default variables for aerospace-wm role
 dev_user: "{{ ansible_user | default('stonecharioteer') }}"
-dev_home: "{{ ansible_env.HOME | default('/Users/' + dev_user) }}"
+dev_home: "{{ ansible_facts.env.HOME | default('/Users/' + dev_user) }}"
 
 # Optional: AeroSpace dotfiles repository
 # aerospace_dotfiles_repo: "git@github.com:stonecharioteer/dotfiles-aerospace.git"

--- a/roles/aerospace-wm/tasks/main.yml
+++ b/roles/aerospace-wm/tasks/main.yml
@@ -2,10 +2,10 @@
 # AeroSpace tiling window manager installation
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 # AeroSpace is macOS-only
 - name: Display message for non-macOS systems
   debug:
     msg: "AeroSpace is a macOS-only tiling window manager"
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"

--- a/roles/cli-tools/defaults/main.yml
+++ b/roles/cli-tools/defaults/main.yml
@@ -75,8 +75,8 @@ cargo_tools:
 
   ast-grep:
     package: "ast-grep"
-    binary: "sg"
-    check_cmd: "sg --version"
+    binary: "ast-grep"
+    check_cmd: "ast-grep --version"
 
 # Cargo tools to install via cargo binstall on macOS (others use Homebrew)
 macos_cargo_tools:

--- a/roles/cli-tools/tasks/darwin.yml
+++ b/roles/cli-tools/tasks/darwin.yml
@@ -32,7 +32,7 @@
 
 - name: Install cargo-based tools on macOS
   shell: |
-    source {{ ansible_env.HOME }}/.cargo/env
+    source {{ ansible_facts.env.HOME }}/.cargo/env
     if ! command -v "{{ item.value.binary }}" &>/dev/null; then
       echo "Installing {{ item.value.package }}..."
       cargo binstall -y "{{ item.value.package }}"
@@ -47,7 +47,7 @@
     label: "{{ item.key }}"
   become: no
   environment:
-    HOME: "{{ ansible_env.HOME }}"
+    HOME: "{{ ansible_facts.env.HOME }}"
   register: macos_cargo_results
   changed_when: "'Installing' in item.stdout | default('')"
   ignore_errors: yes

--- a/roles/cli-tools/tasks/main.yml
+++ b/roles/cli-tools/tasks/main.yml
@@ -2,20 +2,20 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Install CLI development tools via package manager
   package:
     name: "{{ cli_packages }}"
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Create fd symlink (Ubuntu packages fd-find as fdfind)
   file:
     src: /usr/bin/fdfind
     dest: /usr/local/bin/fd
     state: link
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
   ignore_errors: yes
 
 - name: Check if Starship is already installed
@@ -52,7 +52,7 @@
         msg: "✓ Starship installed: {{ starship_version.stdout }}"
 
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - starship_check.rc != 0
   rescue:
     - name: Display Starship installation failure
@@ -93,7 +93,7 @@
         msg: "✓ Gum installed: {{ gum_version.stdout }}"
 
   when:
-    - ansible_os_family == "Debian"
+    - ansible_facts["os_family"] == "Debian"
     - gum_check.rc != 0
   rescue:
     - name: Display Gum installation failure
@@ -134,7 +134,7 @@
         msg: "✓ Glow installed: {{ glow_version.stdout }}"
 
   when:
-    - ansible_os_family == "Debian"
+    - ansible_facts["os_family"] == "Debian"
     - glow_check.rc != 0
   rescue:
     - name: Display Glow installation failure
@@ -185,7 +185,7 @@
         else
           echo "{{ item.value.binary }} is already installed"
         fi
-        {{ item.value.check_cmd }}
+        {{ item.value.check_cmd }} || true
       args:
         executable: /bin/bash
       loop: "{{ cargo_tools | dict2items }}"
@@ -203,7 +203,7 @@
       when: "'bandwhich' in (cargo_tools | list)"
 
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - cargo_check.rc == 0
   rescue:
     - name: Display cargo tools installation failure
@@ -228,7 +228,7 @@
     msg: |
       CLI Development Tools Installation Summary:
 
-      {% if ansible_os_family == "Darwin" %}
+      {% if ansible_facts['os_family'] == "Darwin" %}
       ✓ All CLI tools installed via Homebrew on macOS
       {% else %}
       Package-based tools: {{ cli_packages | join(', ') }}

--- a/roles/dev-folders/tasks/main.yml
+++ b/roles/dev-folders/tasks/main.yml
@@ -4,7 +4,7 @@
     path: "{{ item.path }}"
     state: directory
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
     mode: "{{ item.mode }}"
   loop: "{{ dev_directories }}"
   become: no
@@ -37,7 +37,7 @@
     dest: "{{ item.dest }}"
     state: link
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
   loop:
     - src: "{{ dev_home }}/code/checkouts/personal"
       dest: "{{ dev_home }}/personal"

--- a/roles/docker/tasks/darwin.yml
+++ b/roles/docker/tasks/darwin.yml
@@ -18,7 +18,7 @@
     path: "{{ item }}"
     state: directory
     mode: '0755'
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ ansible_facts['user_id'] }}"
     group: admin
   become: yes
   loop:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Check if Docker is already installed
   command: docker --version
@@ -98,7 +98,7 @@
         msg: "✓ Docker installed: {{ docker_version_verify.stdout }}"
 
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - docker_version_check.rc != 0
   rescue:
     - name: Display Docker installation failure
@@ -148,13 +148,13 @@
       file:
         path: "{{ dev_home }}/.docker"
         owner: "{{ dev_user }}"
-        group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+        group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
         recurse: yes
         mode: 'g+rwx'
       when: user_in_docker_group.rc != 0
       ignore_errors: yes
 
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"
 
 - name: Verify Docker installation and configuration
   block:
@@ -190,4 +190,4 @@
           2. After re-login, test with: docker run hello-world
           3. No sudo required for docker commands after re-login
 
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"

--- a/roles/failsafe-checks/tasks/main.yml
+++ b/roles/failsafe-checks/tasks/main.yml
@@ -255,13 +255,19 @@
   when: fish_config_exists.stat.exists and fish_is_git_repo.stat.exists
   changed_when: false
 
-# FAILSAFE: Stop if fish config exists but is not the correct repository
-- name: FAILSAFE - Stop if fish config exists but is not our repository
-  fail:
+# FAILSAFE: If fish config exists but is not a git repo, back it up so the clone can proceed
+- name: FAILSAFE - Back up non-git fish config directory
+  command: mv {{ dev_home }}/.config/fish {{ dev_home }}/.config/fish.bak.{{ ansible_date_time.iso8601_basic_short }}
+  become_user: "{{ dev_user }}"
+  when:
+    - fish_config_exists.stat.exists
+    - not fish_is_git_repo.stat.exists
+
+- name: Notify about fish config backup
+  debug:
     msg: |
-      STOP: ~/.config/fish exists but is not a git repository.
-      This could be a different fish configuration. Please backup or remove it manually.
-      Found at: {{ dev_home }}/.config/fish
+      ~/.config/fish existed but was not a git repository.
+      It has been backed up to: {{ dev_home }}/.config/fish.bak.{{ ansible_date_time.iso8601_basic_short }}
   when:
     - fish_config_exists.stat.exists
     - not fish_is_git_repo.stat.exists

--- a/roles/fish-config/tasks/main.yml
+++ b/roles/fish-config/tasks/main.yml
@@ -60,7 +60,7 @@
     path: "{{ dev_home }}/.local/bin"
     state: directory
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
     mode: '0755'
   become: no
 

--- a/roles/fish-repository-setup/tasks/main.yml
+++ b/roles/fish-repository-setup/tasks/main.yml
@@ -18,6 +18,7 @@
     version: main
     update: "{{ not fish_config_repo_exists }}"  # Only update if it's a new clone
     force: no  # Never force, to preserve local changes
+    accept_hostkey: yes
   become_user: "{{ dev_user }}"
   when: not fish_config_repo_exists
 
@@ -56,5 +57,5 @@
   file:
     path: "{{ dev_home }}/.config/fish"
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
     recurse: yes

--- a/roles/fish-shell/tasks/main.yml
+++ b/roles/fish-shell/tasks/main.yml
@@ -2,18 +2,18 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Update package cache (Debian/Ubuntu)
   apt:
     update_cache: yes
     cache_valid_time: 86400
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Update package cache (Arch)
   pacman:
     update_cache: yes
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts["os_family"] == "Archlinux"
 
 - name: Install Fish shell and dependencies (Debian/Ubuntu)
   package:
@@ -26,7 +26,7 @@
       - pkg-config
       - libssl-dev
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install Fish shell and dependencies (Arch)
   package:
@@ -39,7 +39,7 @@
       - openssl
       - pkg-config
     state: present
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts["os_family"] == "Archlinux"
 
 - name: Install Fish shell and dependencies (Fedora)
   package:
@@ -54,7 +54,7 @@
       - openssl-devel
       - pkg-config
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts["os_family"] == "RedHat"
 
 - name: Check if user exists
   user:
@@ -62,7 +62,7 @@
     state: present
   register: user_check
   ignore_errors: yes
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"
 
 - name: Create user if it doesn't exist
   user:
@@ -72,7 +72,7 @@
     groups: sudo
     append: yes
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - user_check is failed
 
 - name: Set Fish as default shell for user
@@ -80,7 +80,7 @@
     name: "{{ dev_user }}"
     shell: /usr/bin/fish
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - user_check is succeeded
 
 - name: Install modern CLI tools via package manager (Debian/Ubuntu)
@@ -89,7 +89,7 @@
       - fzf
       - fd-find  # Note: binary is 'fdfind' on Debian/Ubuntu
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
   ignore_errors: yes  # These might not be available in all repos
 
 - name: Install modern CLI tools via package manager (Arch)
@@ -102,7 +102,7 @@
       - dust
       - bottom
     state: present
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts["os_family"] == "Archlinux"
   ignore_errors: yes
 
 - name: Install modern CLI tools via package manager (Fedora)
@@ -113,5 +113,5 @@
       - ripgrep
       - bat
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts["os_family"] == "RedHat"
   ignore_errors: yes

--- a/roles/ghostty/defaults/main.yml
+++ b/roles/ghostty/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Default variables for ghostty role
 dev_user: "{{ ansible_user | default('stonecharioteer') }}"
-dev_home: "{{ ansible_env.HOME | default('/Users/' + dev_user) }}"
+dev_home: "{{ ansible_facts.env.HOME | default('/Users/' + dev_user) }}"
 
 # Optional: Ghostty dotfiles repository
 # ghostty_dotfiles_repo: "git@github.com:stonecharioteer/dotfiles-ghostty.git"

--- a/roles/ghostty/tasks/main.yml
+++ b/roles/ghostty/tasks/main.yml
@@ -2,10 +2,10 @@
 # Ghostty terminal emulator installation
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 # Ghostty is macOS-only for now
 - name: Display message for non-macOS systems
   debug:
     msg: "Ghostty is currently only available for macOS"
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"

--- a/roles/git-config/defaults/main.yml
+++ b/roles/git-config/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Default variables for git-config role
 dev_user: "{{ ansible_user | default('stonecharioteer') }}"
-dev_home: "{{ ansible_env.HOME | default('/home/' + dev_user) }}"
+dev_home: "{{ ansible_facts.env.HOME | default('/home/' + dev_user) }}"
 
 # Git configuration settings
 git_config:

--- a/roles/git-config/tasks/main.yml
+++ b/roles/git-config/tasks/main.yml
@@ -2,8 +2,8 @@
 # Git global configuration tasks
 
 - name: Include platform-specific tasks
-  include_tasks: "{{ ansible_os_family | lower }}.yml"
-  when: ansible_os_family == "Darwin"
+  include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Configure git settings
   community.general.git_config:
@@ -17,7 +17,7 @@
   loop_control:
     label: "{{ item.name }}"
   become: no
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"
 
 - name: Configure git aliases
   community.general.git_config:
@@ -28,7 +28,7 @@
   loop_control:
     label: "alias.{{ item.key }}"
   become: no
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"
 
 - name: Display git configuration status
   debug:
@@ -38,4 +38,4 @@
       - pull.rebase: {{ git_config.pull.rebase }}
       - init.defaultBranch: {{ git_config.init.defaultBranch }}
       Aliases: {{ git_aliases | map(attribute='key') | join(', ') }}
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"

--- a/roles/hugo/defaults/main.yml
+++ b/roles/hugo/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for hugo
 hugo_version: "0.146.7"
-dev_user: "{{ ansible_user_id }}"
-dev_home: "{{ ansible_env.HOME }}"
+dev_user: "{{ ansible_facts['user_id'] }}"
+dev_home: "{{ ansible_facts.env.HOME }}"

--- a/roles/hugo/tasks/main.yml
+++ b/roles/hugo/tasks/main.yml
@@ -2,12 +2,12 @@
 # tasks file for hugo (Linux)
 
 - name: Include platform-specific tasks
-  include_tasks: "{{ ansible_os_family | lower }}.yml"
-  when: ansible_os_family == "Darwin"
+  include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
+  when: ansible_facts["os_family"] == "Darwin"
   tags: blog
 
 - name: Install Hugo Extended on Linux
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
   tags: blog
   block:
     - name: Check if Hugo is already installed

--- a/roles/locale-setup/tasks/main.yml
+++ b/roles/locale-setup/tasks/main.yml
@@ -3,7 +3,7 @@
   package:
     name: locales
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Generate en_US.UTF-8 locale
   locale_gen:

--- a/roles/mise-tools/tasks/main.yml
+++ b/roles/mise-tools/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
   tags: blog
 
 - name: Install essential build tools (Debian/Ubuntu)
@@ -37,7 +37,7 @@
       - liblzma-dev
       - uuid-dev
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install essential build tools (Arch)
   package:
@@ -71,7 +71,7 @@
       - xz
       - util-linux
     state: present
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts["os_family"] == "Archlinux"
 
 - name: Install essential build tools (Fedora)
   package:
@@ -106,7 +106,7 @@
       - xz-devel
       - libuuid-devel
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts["os_family"] == "RedHat"
 
 - name: Check if mise is already installed
   stat:
@@ -129,7 +129,7 @@
     path: "{{ dev_home }}/.config/mise"
     state: directory
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
     mode: '0755'
   become: no
   tags: blog
@@ -191,5 +191,5 @@
     regexp: "^SETUVAR dev_user_paths:"
     create: yes
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
   become: no

--- a/roles/neovim-latest/defaults/main.yml
+++ b/roles/neovim-latest/defaults/main.yml
@@ -3,12 +3,12 @@
 dev_user: "{{ ansible_user | default('stonecharioteer') }}"
 dev_home: "/home/{{ dev_user }}"
 
-# Neovim installation configuration  
-neovim_version: "v0.11.2"
+# Neovim installation configuration
+neovim_version: "v0.11.6"
 neovim_install_prefix: "/usr/local"
 neovim_binary_path: "{{ neovim_install_prefix }}/bin/nvim"
 neovim_vim_symlink_path: "{{ neovim_install_prefix }}/bin/vim"
 
-# Download URLs for Neovim 0.11.2
-neovim_download_url: "https://github.com/neovim/neovim/releases/download/{{ neovim_version }}/nvim-linux64.tar.gz"
+# Download URLs for Neovim (tarball name changed in 0.11.x releases)
+neovim_download_url: "https://github.com/neovim/neovim/releases/download/{{ neovim_version }}/nvim-linux-x86_64.tar.gz"
 neovim_download_dir: "/tmp/neovim-install"

--- a/roles/neovim-latest/tasks/main.yml
+++ b/roles/neovim-latest/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
   tags: blog
 
 - name: Check if Neovim is already installed
@@ -43,12 +43,12 @@
     - name: Download Neovim {{ neovim_version }}
       get_url:
         url: "{{ neovim_download_url }}"
-        dest: "{{ neovim_download_dir }}/nvim-linux64.tar.gz"
+        dest: "{{ neovim_download_dir }}/nvim-linux-x86_64.tar.gz"
         mode: '0644'
 
     - name: Extract Neovim archive
       unarchive:
-        src: "{{ neovim_download_dir }}/nvim-linux64.tar.gz"
+        src: "{{ neovim_download_dir }}/nvim-linux-x86_64.tar.gz"
         dest: "{{ neovim_download_dir }}"
         remote_src: yes
 
@@ -60,19 +60,19 @@
 
     - name: Install Neovim binary
       copy:
-        src: "{{ neovim_download_dir }}/nvim-linux64/bin/nvim"
+        src: "{{ neovim_download_dir }}/nvim-linux-x86_64/bin/nvim"
         dest: "{{ neovim_binary_path }}"
         mode: '0755'
         remote_src: yes
 
     - name: Install Neovim share files
       shell: |
-        cp -r "{{ neovim_download_dir }}/nvim-linux64/share/nvim" "{{ neovim_install_prefix }}/share/"
+        cp -r "{{ neovim_download_dir }}/nvim-linux-x86_64/share/nvim" "{{ neovim_install_prefix }}/share/"
         chmod -R 755 "{{ neovim_install_prefix }}/share/nvim"
 
     - name: Install Neovim lib files  
       shell: |
-        cp -r "{{ neovim_download_dir }}/nvim-linux64/lib/nvim" "{{ neovim_install_prefix }}/lib/"
+        cp -r "{{ neovim_download_dir }}/nvim-linux-x86_64/lib/nvim" "{{ neovim_install_prefix }}/lib/"
         chmod -R 755 "{{ neovim_install_prefix }}/lib/nvim"
 
     - name: Create vim symlink to nvim
@@ -100,7 +100,7 @@
           Version: {{ neovim_version_check.stdout_lines[0] }}
 
   when:
-    - ansible_os_family != "Darwin"
+    - ansible_facts["os_family"] != "Darwin"
     - not neovim_exists.stat.exists or (neovim_exists.stat.exists and neovim_version not in installed_neovim_version.stdout)
   rescue:
     - name: Clean up on failure

--- a/roles/nerd-fonts/tasks/main.yml
+++ b/roles/nerd-fonts/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Install fonts on Linux
   block:
@@ -52,4 +52,4 @@
         msg: "INFO: install/fonts directory not found - installed from package manager instead. JetBrainsMono Nerd Font files should be in install/fonts/ for full icon support"
       when: not fonts_dir.stat.exists
 
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"

--- a/roles/repository-setup/tasks/main.yml
+++ b/roles/repository-setup/tasks/main.yml
@@ -7,6 +7,7 @@
     version: main
     update: "{{ not qtile_config_repo_exists }}"  # Only update if it's a new clone
     force: no  # Never force, to preserve local changes
+    accept_hostkey: yes
   become_user: "{{ dev_user }}"
   when: not qtile_config_repo_exists
 
@@ -55,6 +56,7 @@
     version: master
     update: no  # Never update existing repos
     force: no   # Never force, to preserve local changes
+    accept_hostkey: yes
   become_user: "{{ dev_user }}"
   when: not alacritty_source_repo_exists
 

--- a/roles/rust-toolchain/tasks/main.yml
+++ b/roles/rust-toolchain/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Check if rustup is already installed
   stat:
@@ -87,7 +87,7 @@
     regexp: "^SETUVAR dev_user_paths:"
     create: yes
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
   become: no
 
 - name: Ensure cargo bin directory is in PATH
@@ -96,5 +96,5 @@
     line: 'export PATH="$HOME/.cargo/bin:$PATH"'
     create: yes
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
   become: no

--- a/roles/scripts-repository-setup/tasks/main.yml
+++ b/roles/scripts-repository-setup/tasks/main.yml
@@ -19,6 +19,7 @@
     version: main
     update: "{{ scripts_can_update | default(false) }}"  # Only update if on main branch with no unstaged changes
     force: no  # Never force, to preserve local changes
+    accept_hostkey: yes
   become_user: "{{ dev_user }}"
   when: not scripts_repo_exists
 
@@ -64,7 +65,7 @@
   file:
     path: "{{ dev_home }}/code/checkouts/personal/scripts"
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
     recurse: yes
   when: scripts_repo_exists or (not scripts_repo_exists)
 
@@ -83,7 +84,7 @@
     regexp: "^fish_add_path.*scripts$"
     create: yes
     owner: "{{ dev_user }}"
-    group: "{{ 'staff' if ansible_os_family == 'Darwin' else dev_user }}"
+    group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
   when: scripts_repo_exists or (not scripts_repo_exists)
   ignore_errors: yes
 

--- a/roles/server-hardening/defaults/main.yml
+++ b/roles/server-hardening/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Server hardening defaults
+
+# Timezone
+server_timezone: "Asia/Kolkata"
+
+# Locale
+server_locale: "en_US.UTF-8"
+
+# Unattended upgrades: auto-reboot time (24h format)
+auto_reboot_time: "07:00"
+
+# Only apply security updates automatically
+unattended_upgrades_origins:
+  - "${distro_id}:${distro_codename}-security"

--- a/roles/server-hardening/handlers/main.yml
+++ b/roles/server-hardening/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart unattended-upgrades
+  systemd:
+    name: unattended-upgrades
+    state: restarted

--- a/roles/server-hardening/tasks/main.yml
+++ b/roles/server-hardening/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+# Server hardening: timezone, automatic security updates, needrestart
+# Only runs on Debian/Ubuntu systems
+
+- name: Set timezone
+  timezone:
+    name: "{{ server_timezone }}"
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Install server hardening packages
+  apt:
+    name:
+      - needrestart
+      - unattended-upgrades
+      - apt-listchanges
+    state: present
+    install_recommends: no
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Configure unattended-upgrades
+  template:
+    src: 50unattended-upgrades.j2
+    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart unattended-upgrades
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Configure auto-upgrades schedule
+  template:
+    src: 20auto-upgrades.j2
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart unattended-upgrades
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Configure needrestart for automatic restarts
+  template:
+    src: needrestart-autorestart.conf.j2
+    dest: /etc/needrestart/conf.d/50-autorestart.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Configure apt-listchanges
+  template:
+    src: apt-listchanges.conf.j2
+    dest: /etc/apt/listchanges.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: ansible_facts["os_family"] == "Debian"
+
+- name: Enable and start unattended-upgrades service
+  systemd:
+    name: unattended-upgrades
+    enabled: yes
+    state: started
+  when: ansible_facts["os_family"] == "Debian"

--- a/roles/server-hardening/templates/20auto-upgrades.j2
+++ b/roles/server-hardening/templates/20auto-upgrades.j2
@@ -1,0 +1,4 @@
+// Ansible managed - do not edit manually
+
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";

--- a/roles/server-hardening/templates/50unattended-upgrades.j2
+++ b/roles/server-hardening/templates/50unattended-upgrades.j2
@@ -1,0 +1,15 @@
+// Ansible managed - do not edit manually
+
+Unattended-Upgrade::Allowed-Origins {
+{% for origin in unattended_upgrades_origins %}
+    "{{ origin }}";
+{% endfor %}
+};
+
+Unattended-Upgrade::Package-Blacklist {
+};
+
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ auto_reboot_time }}";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";

--- a/roles/server-hardening/templates/apt-listchanges.conf.j2
+++ b/roles/server-hardening/templates/apt-listchanges.conf.j2
@@ -1,0 +1,8 @@
+# Ansible managed - do not edit manually
+
+[apt]
+frontend=pager
+which=news
+email_address=root
+confirm=false
+save_seen=/var/lib/apt/listchanges.db

--- a/roles/server-hardening/templates/needrestart-autorestart.conf.j2
+++ b/roles/server-hardening/templates/needrestart-autorestart.conf.j2
@@ -1,0 +1,3 @@
+# Ansible managed - do not edit manually
+# Automatically restart services after upgrades
+$nrconf{restart} = 'a';

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -2,7 +2,7 @@
 # Include macOS-specific tasks
 - name: Include macOS-specific tasks
   include_tasks: darwin.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
   tags: blog
 
 - name: Check if tmux is already installed
@@ -24,7 +24,7 @@
       package:
         name: "{{ tmux_build_deps }}"
         state: present
-      when: ansible_os_family != "Darwin"
+      when: ansible_facts["os_family"] != "Darwin"
 
     - name: Create build directory
       file:
@@ -74,7 +74,7 @@
     - name: Compile tmux
       shell: |
         cd "{{ tmux_source_dir.files[0].path }}"
-        make -j{{ ansible_processor_vcpus }}
+        make -j{{ ansible_facts['processor_vcpus'] }}
       args:
         chdir: "{{ tmux_source_dir.files[0].path }}"
 
@@ -102,7 +102,7 @@
           Version: {{ tmux_version_check.stdout }}
           Location: {{ tmux_binary_path }}
 
-  when: not tmux_exists.stat.exists and ansible_os_family != "Darwin"
+  when: not tmux_exists.stat.exists and ansible_facts["os_family"] != "Darwin"
   rescue:
     - name: Clean up on failure
       file:
@@ -117,7 +117,7 @@
 # Install/update oh-my-tmux configuration (shared across platforms)
 - name: Configure oh-my-tmux
   include_tasks: configure.yml
-  when: ansible_os_family != "Darwin"
+  when: ansible_facts["os_family"] != "Darwin"
   tags:
     - oh-my-tmux
     - blog


### PR DESCRIPTION
## Summary

- **Server hardening role**: Automatic security updates via `unattended-upgrades`, `needrestart` auto-restart, timezone configuration (Asia/Kolkata), and `apt-listchanges` — Debian/Ubuntu only
- **Deprecation fixes**: Replace all `ansible_os_family`, `ansible_env.*`, `ansible_user_id` etc. with `ansible_facts[...]` equivalents across 45+ files to eliminate `INJECT_FACTS_AS_VARS` warnings
- **YAML quoting fix**: Use single quotes for `ansible_facts['key']` inside double-quoted YAML strings to prevent parse errors
- **Neovim update**: Bump to v0.11.6, fix tarball name change (`nvim-linux-x86_64.tar.gz`)
- **ast-grep fix**: Use `ast-grep` binary name instead of `sg` (conflicts with system setgroups command)
- **Cargo tools resilience**: Make version checks non-fatal for tools like `amdgpu_top` that need runtime libraries absent on headless servers
- **SSH host key**: Add `accept_hostkey: yes` to git clone tasks for fresh server deployments
- **Failsafe improvement**: Back up existing non-git fish config instead of hard-failing
- **Justfile**: Add `setup-linux-server` recipe for one-command headless server provisioning
- **Interpreter warning**: Add `interpreter_python = auto_silent` to suppress Python discovery warnings

## Test plan
- [x] Full playbook run against headless Ubuntu 24.04 LXC (stone-node.home.arpa)
- [x] All 166 tasks pass (ok=166, changed=38, failed=0, ignored=4)
- [ ] Verify idempotency on re-run
- [ ] Test macOS playbook still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)