### PR TITLE
feat(herdr): install herdr on Linux and macOS base environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This is an Ansible-based dotfiles and development environment automation reposit
 ### Running Playbooks
 
 **Ubuntu/Debian (Simple 2-playbook setup):**
+
 ```bash
 # Base development environment (for ALL systems)
 ansible-playbook --ask-become-pass playbooks/base-environment.yml
@@ -20,6 +21,7 @@ ansible-playbook --ask-become-pass playbooks/gui-environment.yml
 ```
 
 **macOS (Simple 2-playbook setup):**
+
 ```bash
 # Base development environment (for ALL macOS systems)
 ansible-playbook playbooks/macos-base-environment.yml
@@ -33,21 +35,25 @@ Note: macOS playbooks use Homebrew and don't require `--ask-become-pass` for mos
 ### Ansible Operations
 
 Run specific tags only:
+
 ```bash
 ansible-playbook --ask-become-pass playbooks/gui.yml --tags docker
 ```
 
 Skip certain tags:
+
 ```bash
 ansible-playbook --ask-become-pass playbooks/gui.yml --skip-tags "qtile,docker"
 ```
 
 List all available tags:
+
 ```bash
 ansible-playbook playbooks/servers.yml --list-tags
 ```
 
 List all tasks and roles:
+
 ```bash
 ansible-playbook playbooks/servers.yml --list-tasks
 ```
@@ -55,21 +61,25 @@ ansible-playbook playbooks/servers.yml --list-tasks
 ### Testing with Vagrant
 
 Bring up test VMs:
+
 ```bash
 vagrant up
 ```
 
 Test with a specific playbook:
+
 ```bash
 ansible-playbook playbooks/servers.yml
 ```
 
 Destroy test VMs:
+
 ```bash
 vagrant destroy -f
 ```
 
 Clean SSH known_hosts after testing:
+
 ```bash
 ssh-keygen -R "192.168.60.2"
 ssh-keygen -R "192.168.60.3"
@@ -79,12 +89,14 @@ ssh-keygen -R "192.168.60.4"
 ## Repository Quality Gates
 
 Pre-commit is the canonical local and CI quality gate for this repository:
+
 ```bash
 pre-commit install
 pre-commit run --all-files
 ```
 
 Current checks intentionally start broad but non-disruptive:
+
 - commit-message guards enforce Conventional Commits and block AI attribution footers such as `Co-authored-by: Claude` and `Generated with Claude Code`
 - generic file hygiene via `pre-commit-hooks`
 - YAML parsing/style via `yamllint`
@@ -93,6 +105,7 @@ Current checks intentionally start broad but non-disruptive:
 - local Ansible guardrails that reject risky direct binary probe tasks such as `command: tool --version` in check tasks without `failed_when: false`
 
 The `.ansible-lint` and `.yamllint` configs include compatibility skips for the existing playbooks. As roles are modernized, tighten these rules incrementally instead of removing the hooks:
+
 1. remove skipped `ansible-lint` rules one category at a time
 2. prefer fixing existing violations over adding new skips
 3. keep CI required on PRs to `main` so regressions are caught before merge
@@ -121,6 +134,7 @@ Preserve the inventory split when adding machines or features:
 The repository uses a **unified role-based architecture** with all functionality consolidated:
 
 **All Components Now Use Roles** (`roles/`):
+
 - All external configurations migrated into this repository
 - Consistent role structure with proper variable scoping, handlers, and modularity
 - Single source of truth for all environment automation
@@ -128,40 +142,48 @@ The repository uses a **unified role-based architecture** with all functionality
 ### Main Playbooks
 
 **Ubuntu/Debian:**
+
 - **playbooks/base-environment.yml**: Complete development environment for ALL Ubuntu/Debian systems
-  - Fish shell + dotfiles, mise + languages, development tools, tmux, neovim, docker
+  - Fish shell + dotfiles, mise + languages, development tools, tmux, herdr, neovim, docker
 - **playbooks/gui-environment.yml**: Complete GUI workstation (includes base + desktop)
   - Everything from base-environment.yml + Qtile + fonts + Alacritty + desktop integration
 
 **macOS:**
+
 - **playbooks/macos-base-environment.yml**: Complete development environment for ALL macOS systems
-  - Fish shell + dotfiles, mise + languages, development tools, tmux (Homebrew), neovim (Homebrew), docker
+  - Fish shell + dotfiles, mise + languages, development tools, tmux (Homebrew), herdr, neovim (Homebrew), docker
 - **playbooks/macos-gui-environment.yml**: Complete GUI workstation (includes base + GUI apps)
   - Everything from macos-base-environment.yml + JetBrains Mono Nerd Font + Ghostty + AeroSpace WM
 
 ### Legacy Playbooks (DEPRECATED)
+
 - All other playbooks replaced by the simple 2-playbook approach per platform
 
 ### Consolidated Roles (`roles/`)
 
 **Platform Support:**
+
 - All roles support Ubuntu/Debian via package managers (apt)
 - macOS support via Homebrew (roles include `darwin.yml` task files)
 - Conditional includes based on `ansible_os_family`
 
 **Shell Environment:**
+
 - **fish-shell**: Fish shell installation and setup (apt/Homebrew)
 - **mise-tools**: Runtime version manager (Node.js, Python, Go, Rust via mise)
 - **rust-toolchain**: Enhanced Rust toolchain with cargo-binstall
 - **fish-config**: Fish configuration and abbreviations
 
 **Development Tools:**
+
 - **system-deps**: Essential system dependencies and development headers
+
   - Core system tools (`curl`, `git`, `htop`, `build-essential`)
   - Development libraries (`libssl-dev`, `libffi-dev`, `pkg-config`)
   - Python3 system packages and build tools
 
 - **cli-tools**: Modern CLI development tools
+
   - File/text search: `ripgrep`, `fd-find`, `fzf`, `tree`
   - Development utilities: `direnv`, `httpie`, `zoxide`
   - File watching: `watchexec-cli` (via cargo binstall)
@@ -169,6 +191,7 @@ The repository uses a **unified role-based architecture** with all functionality
   - Fun utilities: `cowsay`, `fortune`, `lolcat`, `neofetch`
 
 - **dev-folders**: Creates standardized development directory structure
+
   - `~/code/checkouts/{personal,work}/`
   - `~/code/tools/`, `~/workspace/{projects,scratch}/`
   - `~/Pictures/screenshots/`, `~/.local/bin/`
@@ -178,6 +201,12 @@ The repository uses a **unified role-based architecture** with all functionality
   - Clones https://github.com/gpakosz/.tmux to ~/.tmux/
   - Creates ~/.tmux.conf symlink and ~/.tmux.conf.local with sensible defaults
   - Enables powerline separators (requires Nerd Fonts for proper display)
+- **herdr**: Terminal workspace manager for AI coding agents
+  - Installs the public stable binary from https://herdr.dev/latest.json into `~/.local/bin/herdr`
+  - Verifies the GitHub release SHA-256 checksum instead of running `curl | sh`
+  - Deploys shared config: prefix `ctrl+a`, bottom tab bar, system toast delivery
+  - Installs a portable `~/.config/herdr/status.sh` for load and battery in the tab bar
+  - Controlled by `enable_herdr`, default true in `group_vars/all.yml`
 - **neovim-latest**: Installs Neovim 0.11.2 binary with vim symlink (Linux) or via Homebrew (macOS)
 - **tree-sitter-cli**: Installs tree-sitter CLI via npm (uses mise Node.js)
 - **nvim-config**: Sets up custom Neovim configuration with plugins
@@ -189,6 +218,7 @@ The repository uses a **unified role-based architecture** with all functionality
 - **laptop-health**: Linux laptop/server-mode health monitoring, lid-ignore config, NVMe SMART snapshots, and X13 Flow-specific display/GPU mitigations through feature flags
 
 **GUI Environment (Linux):**
+
 - **locale-setup**: System locale configuration
 - **base-system**: Essential system packages
 - **qtile-wm**: Qtile window manager installation + Adwaita cursor theme
@@ -196,6 +226,7 @@ The repository uses a **unified role-based architecture** with all functionality
 - **desktop-integration**: Desktop session management + dark mode preference + cursor configuration
 
 **GUI Environment (macOS):**
+
 - **nerd-fonts**: JetBrains Mono Nerd Font installation (via Homebrew cask)
 - **ghostty**: Ghostty terminal emulator (GPU-accelerated, native macOS)
   - Config stored in `roles/ghostty/files/config`
@@ -207,12 +238,14 @@ The repository uses a **unified role-based architecture** with all functionality
 ### Dependency Management
 
 **All Dependencies Consolidated** (no external setups required):
+
 - **Node.js/npm**: Now managed by `mise-tools` role in this repository
 - **Rust/Cargo**: Now managed by `rust-toolchain` role in this repository
 - **Fonts**: Now managed by `nerd-fonts` role in this repository
 - **Fish shell + tools**: Now managed by fish roles in this repository
 
 **Role Dependencies**:
+
 - `tree-sitter-cli` → requires Node.js (provided by `mise-tools`)
 - `astronvim-config` → requires `neovim-latest` + `tree-sitter-cli`
 - All roles use standard variables: `dev_user`, `dev_home`
@@ -220,15 +253,18 @@ The repository uses a **unified role-based architecture** with all functionality
 ### Key Tools Installed
 
 **Shell Environment**:
+
 - **Fish shell**: Modern shell with syntax highlighting
 - **mise**: Runtime version manager (Node.js, Python, Go, Rust)
 - **Rust toolchain**: Enhanced with cargo-binstall
 - **Fish configuration**: Abbreviations and modern integrations
 
 **Development Tools**:
+
 - **System Dependencies**: Build tools, development headers, Python3 system packages
 - **CLI Tools**: ripgrep, fd-find, fzf, starship, gum, direnv, httpie, zoxide, watchexec
 - **tmux**: Latest version compiled from source (Linux) or via Homebrew (macOS)
+- **herdr**: Terminal workspace manager installed from herdr.dev into `~/.local/bin`
 - **Neovim**: 0.11.2 binary with vim symlink (Linux) or via Homebrew (macOS)
 - **Custom Neovim config**: Complete configuration with plugin setup
 - **tree-sitter CLI**: Via npm for syntax highlighting
@@ -236,6 +272,7 @@ The repository uses a **unified role-based architecture** with all functionality
 - **Docker**: Latest Engine with Compose (Linux) or Docker Desktop (macOS)
 
 **GUI Environment (Linux)**:
+
 - **Qtile**: Modern tiling window manager
 - **JetBrains Mono Nerd Font**: Programming font with icons
 - **Alacritty**: GPU-accelerated terminal emulator
@@ -243,6 +280,7 @@ The repository uses a **unified role-based architecture** with all functionality
 - **Adwaita Cursor Theme**: 16px cursor theme for high-DPI displays
 
 **GUI Environment (macOS)**:
+
 - **JetBrains Mono Nerd Font**: Programming font with icons (via Homebrew)
 - **Ghostty**: GPU-accelerated terminal emulator (native macOS)
 - **AeroSpace**: Tiling window manager (native macOS, i3/sway-like keybindings)

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ just doctor
 
 Then choose the profile that matches the machine you are setting up:
 
-| Profile        | Bootstrap command                              | Playbook                               | Target            | Includes                                                          |
-| -------------- | ---------------------------------------------- | -------------------------------------- | ----------------- | ----------------------------------------------------------------- |
-| Headless Linux | `./bootstrap headless --host HOST --user USER` | `playbooks/base-environment.yml`       | servers/dev boxes | Fish, dotfiles, mise, tmux, Neovim, Hugo, Docker                  |
-| Linux GUI      | `./bootstrap gui --host HOST --user USER`      | `playbooks/gui-environment.yml`        | desktops/laptops  | base tools + Qtile, Nerd Font, Alacritty, desktop integration     |
-| macOS Base     | `./bootstrap mac`                              | `playbooks/macos-base-environment.yml` | MacBooks          | Homebrew, Fish, dotfiles, dev tools, tmux, Neovim, Docker Desktop |
-| macOS GUI      | `./bootstrap mac-gui`                          | `playbooks/macos-gui-environment.yml`  | MacBooks          | macOS base + Ghostty, AeroSpace, Nerd Font                        |
+| Profile        | Bootstrap command                              | Playbook                               | Target            | Includes                                                         |
+| -------------- | ---------------------------------------------- | -------------------------------------- | ----------------- | ---------------------------------------------------------------- |
+| Headless Linux | `./bootstrap headless --host HOST --user USER` | `playbooks/base-environment.yml`       | servers/dev boxes | Fish, dotfiles, mise, tmux, herdr, Neovim, Hugo, Docker          |
+| Linux GUI      | `./bootstrap gui --host HOST --user USER`      | `playbooks/gui-environment.yml`        | desktops/laptops  | base tools + Qtile, Nerd Font, Alacritty, desktop integration    |
+| macOS Base     | `./bootstrap mac`                              | `playbooks/macos-base-environment.yml` | MacBooks          | Homebrew, Fish, dotfiles, dev tools, tmux, herdr, Neovim, Docker |
+| macOS GUI      | `./bootstrap mac-gui`                          | `playbooks/macos-gui-environment.yml`  | MacBooks          | macOS base + Ghostty, AeroSpace, Nerd Font                       |
 
 Examples:
 
@@ -49,6 +49,7 @@ The bootstrap script prints the exact `ansible-playbook` command before running 
 - Fish shell + dotfiles, mise (Node.js, Python, Go, Rust), Rust toolchain
 - CLI tools: ripgrep, fd, fzf, starship, gum, direnv, zoxide, watchexec
 - tmux (compiled from source) + oh-my-tmux with powerline separators
+- herdr terminal workspace manager (prefix `ctrl+a`, bottom tab bar)
 - Neovim 0.11.2 + custom configuration
 - Hugo Extended 0.146.7 (static site generator)
 - Docker Engine + Compose
@@ -60,6 +61,7 @@ The bootstrap script prints the exact `ansible-playbook` command before running 
 - mise (Node.js, Python, Go, Rust), Rust toolchain
 - Same CLI tools via Homebrew
 - tmux (via Homebrew) + oh-my-tmux with powerline separators
+- herdr terminal workspace manager (prefix `ctrl+a`, bottom tab bar)
 - Neovim (via Homebrew) + custom configuration
 - Hugo Extended (static site generator)
 - Docker Desktop
@@ -104,7 +106,7 @@ Recommended inventory model:
 - group real hosts by profile (`headless_machines`, `gui_machines`, `macbooks`), OS (`ubuntu_lts_26_04`), and sudo implementation (`sudo_rs`)
 - keep shared defaults in `inventory/group_vars/all.yml`
 - keep host-specific overrides in `inventory/host_vars/<host>.yml`
-- use feature flags in inventory to opt in/out of components like Docker, Hugo, Tailscale, Qtile, Ghostty, or AeroSpace
+- use feature flags in inventory to opt in/out of components like Docker, Hugo, herdr, Tailscale, Qtile, Ghostty, or AeroSpace
 
 Then run with either bootstrap or Ansible directly:
 
@@ -199,7 +201,7 @@ ansible-playbook --ask-become-pass playbooks/base-environment.yml --tags "fish,t
 **Available Linux tags:**
 
 - **Shell:** `shell`, `fish`, `dotfiles`, `scripts`, `mise`, `rust`, `languages`, `config`
-- **Development:** `dev`, `deps`, `cli`, `folders`, `tmux`, `neovim`, `editor`, `hugo`, `blog`, `docker`, `containers`
+- **Development:** `dev`, `deps`, `cli`, `folders`, `tmux`, `herdr`, `neovim`, `editor`, `hugo`, `blog`, `docker`, `containers`
 - **Networking:** `networking`, `tailscale`
 - **Laptop/server mode:** `laptop`, `health`, `monitoring`
 - **GUI:** `gui`, `system`, `locale`, `repos`, `wm`, `qtile`, `fonts`, `terminal`, `alacritty`, `desktop`, `integration`
@@ -235,7 +237,7 @@ ansible-playbook playbooks/macos-base-environment.yml --tags "fish,tmux,neovim"
 **Available macOS tags:**
 
 - **Shell:** `shell`, `fish`, `dotfiles`, `scripts`, `mise`, `rust`, `languages`, `config`
-- **Development:** `dev`, `cli`, `folders`, `tmux`, `neovim`, `editor`, `hugo`, `blog`, `docker`, `containers`
+- **Development:** `dev`, `cli`, `folders`, `tmux`, `herdr`, `neovim`, `editor`, `hugo`, `blog`, `docker`, `containers`
 - **GUI:** `gui`, `fonts`, `terminal`, `ghostty`, `wm`, `aerospace`
 
 ### Target specific hosts (Ubuntu/Debian)
@@ -295,7 +297,7 @@ ansible-playbook playbooks/base-environment.yml --list-tasks
 
 - Shell: `fish-shell`, `fish-config`, `mise-tools`, `rust-toolchain`
 - CLI: `system-deps`, `cli-tools`, `dev-folders`
-- Development: `tmux`, `neovim-latest`, `nvim-config`, `tree-sitter-cli`, `hugo`, `docker`
+- Development: `tmux`, `herdr`, `neovim-latest`, `nvim-config`, `tree-sitter-cli`, `hugo`, `docker`
 - Optional tooling: `supabase-tooling`
 - GUI (Linux): `qtile-wm`, `alacritty`, `desktop-integration`
 - GUI (macOS): `ghostty`, `aerospace-wm`, `nerd-fonts`

--- a/docs/TOOLS_STRATEGY.md
+++ b/docs/TOOLS_STRATEGY.md
@@ -7,26 +7,31 @@ This document explains how tools are installed across different roles to avoid c
 ## Package Manager Priority
 
 ### Linux (Ubuntu/Debian)
+
 1. **apt** - System package manager (preferred for stability)
 2. **External installers** - For tools not in apt (Starship, Gum)
 3. **cargo-binstall** - For Rust tools not available in apt
 
 ### macOS
+
 1. **Homebrew** - macOS package manager (preferred for everything available)
 2. **cargo-binstall** - For Rust tools not available in Homebrew
 
 ## Tool Distribution by Role
 
 ### `cli-tools` Role
+
 **Purpose**: Install commonly available CLI tools via package managers
 
 **Linux (apt):**
+
 - ripgrep, fd-find, fzf, zoxide, tree
 - direnv, httpie, pgcli
 - htop, jq, yq
 - cowsay, fortune-mod, lolcat, neofetch
 
 **macOS (Homebrew):**
+
 - ripgrep, fd, fzf, zoxide, tree
 - starship (via Homebrew instead of installer)
 - direnv, httpie, pgcli, gum
@@ -34,19 +39,24 @@ This document explains how tools are installed across different roles to avoid c
 - cowsay, fortune, lolcat, neofetch
 
 **External Installers (Linux only):**
+
 - Starship (via starship.rs/install.sh)
 - Gum (via Charm repository)
 
 **Cargo Tools (both platforms):**
+
 - watchexec-cli (only this one, as it's not commonly in package managers)
 
 ### `rust-toolchain` Role
+
 **Purpose**: Install Rust toolchain and Rust-native tools via cargo-binstall
 
 **What it installs (both platforms):**
+
 - rustup, cargo, cargo-binstall
 
 **Essential Rust CLI Tools:**
+
 - bat - Better cat with syntax highlighting
 - tokei - Code statistics
 - du-dust - Better du
@@ -56,6 +66,7 @@ This document explains how tools are installed across different roles to avoid c
 - procs - Better ps
 
 **Additional Rust Tools:**
+
 - sd - Better sed
 - tealdeer - tldr client (quick command help)
 - grex - Regex pattern generator
@@ -72,26 +83,39 @@ This document explains how tools are installed across different roles to avoid c
 ## Tool Categories
 
 ### Core Tools (via Package Manager)
+
 These are essential and widely available:
+
 - **Search**: ripgrep, fd
 - **Navigation**: zoxide, fzf
 - **Shell**: starship (Homebrew on macOS, installer on Linux)
 
 ### Extended Rust Tools (via cargo-binstall)
+
 These enhance the terminal experience but may not be in all package managers:
+
 - **File viewing**: bat, eza
 - **Monitoring**: bottom, procs, du-dust
 - **Utilities**: sd, tealdeer, grex
 - **Development**: tokei, xh
 
+### GitHub Release Binaries
+
+These are not in apt or Homebrew, so the matching role downloads a verified release asset:
+
+- **herdr**: Terminal workspace manager. Installed by the `herdr` role from `https://herdr.dev/latest.json` into `~/.local/bin/herdr`.
+
 ### Development Tools (via Package Manager)
+
 These are development-focused:
+
 - **APIs**: httpie
 - **Databases**: pgcli
 - **Data**: jq, yq
 - **Environment**: direnv
 
 ### System Tools
+
 - **htop**: Process viewer (traditional)
 - **btop**: Modern system resource monitor (C++, better than htop)
 - **tree**: Directory visualization
@@ -99,6 +123,7 @@ These are development-focused:
 ## Installation Flow
 
 ### Linux
+
 ```
 1. cli-tools (apt) → ripgrep, fd, zoxide, starship (external), fzf, etc.
 2. rust-toolchain → rustup, cargo
@@ -106,6 +131,7 @@ These are development-focused:
 ```
 
 ### macOS
+
 ```
 1. cli-tools (Homebrew) → ripgrep, fd, zoxide, starship, fzf, etc.
 2. rust-toolchain → rustup, cargo
@@ -116,42 +142,42 @@ These are development-focused:
 
 ### Installed via cli-tools (Package Manager)
 
-| Tool | Linux | macOS | Purpose |
-|------|-------|-------|---------|
-| ripgrep | ✓ | ✓ | Fast text search |
-| fd | ✓ | ✓ | Fast file search |
-| fzf | ✓ | ✓ | Fuzzy finder |
-| zoxide | ✓ | ✓ | Smart directory navigation |
-| starship | External | ✓ | Modern prompt |
-| direnv | ✓ | ✓ | Environment management |
-| httpie | ✓ | ✓ | HTTP client |
-| pgcli | ✓ | ✓ | PostgreSQL client |
-| jq | ✓ | ✓ | JSON processor |
-| yq | ✓ | ✓ | YAML processor |
-| gum | External | ✓ | Terminal UI |
-| htop | ✓ | ✓ | Process viewer |
-| btop | ✓ | ✓ | Modern system monitor |
-| tree | ✓ | ✓ | Directory tree |
-| cowsay | ✓ | ✓ | ASCII art |
-| fortune | ✓ | ✓ | Random quotes |
-| lolcat | ✓ | ✓ | Colorful output |
-| neofetch | ✓ | ✓ | System info |
+| Tool     | Linux    | macOS | Purpose                    |
+| -------- | -------- | ----- | -------------------------- |
+| ripgrep  | ✓        | ✓     | Fast text search           |
+| fd       | ✓        | ✓     | Fast file search           |
+| fzf      | ✓        | ✓     | Fuzzy finder               |
+| zoxide   | ✓        | ✓     | Smart directory navigation |
+| starship | External | ✓     | Modern prompt              |
+| direnv   | ✓        | ✓     | Environment management     |
+| httpie   | ✓        | ✓     | HTTP client                |
+| pgcli    | ✓        | ✓     | PostgreSQL client          |
+| jq       | ✓        | ✓     | JSON processor             |
+| yq       | ✓        | ✓     | YAML processor             |
+| gum      | External | ✓     | Terminal UI                |
+| htop     | ✓        | ✓     | Process viewer             |
+| btop     | ✓        | ✓     | Modern system monitor      |
+| tree     | ✓        | ✓     | Directory tree             |
+| cowsay   | ✓        | ✓     | ASCII art                  |
+| fortune  | ✓        | ✓     | Random quotes              |
+| lolcat   | ✓        | ✓     | Colorful output            |
+| neofetch | ✓        | ✓     | System info                |
 
 ### Installed via rust-toolchain (cargo-binstall)
 
-| Tool | Both | Purpose |
-|------|------|---------|
-| bat | ✓ | Better cat with syntax highlighting |
-| eza | ✓ | Better ls (modern, colorful) |
-| tokei | ✓ | Code line counter & statistics |
-| bottom | ✓ | Better top/htop (btm command) |
-| du-dust | ✓ | Better du (dust command) |
-| procs | ✓ | Better ps (process viewer) |
-| xh | ✓ | Better httpie (Rust alternative) |
-| sd | ✓ | Better sed (stream editor) |
-| tealdeer | ✓ | tldr client (quick help) |
-| grex | ✓ | Regex pattern generator |
-| gitui | ✓ (Linux) | Terminal UI for git |
+| Tool     | Both      | Purpose                             |
+| -------- | --------- | ----------------------------------- |
+| bat      | ✓         | Better cat with syntax highlighting |
+| eza      | ✓         | Better ls (modern, colorful)        |
+| tokei    | ✓         | Code line counter & statistics      |
+| bottom   | ✓         | Better top/htop (btm command)       |
+| du-dust  | ✓         | Better du (dust command)            |
+| procs    | ✓         | Better ps (process viewer)          |
+| xh       | ✓         | Better httpie (Rust alternative)    |
+| sd       | ✓         | Better sed (stream editor)          |
+| tealdeer | ✓         | tldr client (quick help)            |
+| grex     | ✓         | Regex pattern generator             |
+| gitui    | ✓ (Linux) | Terminal UI for git                 |
 
 ## Verification
 
@@ -183,11 +209,13 @@ tldr --version      # tealdeer
 ## Adding New Tools
 
 ### To add a tool via package manager (cli-tools):
+
 1. Check if available in apt (Ubuntu) and Homebrew (macOS)
 2. Add to `cli_packages` in `roles/cli-tools/defaults/main.yml`
 3. Add to Homebrew list in `roles/cli-tools/tasks/darwin.yml`
 
 ### To add a tool via cargo (rust-toolchain):
+
 1. Check if available on crates.io and cargo-binstall
 2. Add to appropriate list in `roles/rust-toolchain/tasks/main.yml` (Linux)
 3. Add to appropriate list in `roles/rust-toolchain/tasks/darwin.yml` (macOS)
@@ -195,15 +223,18 @@ tldr --version      # tealdeer
 ## Troubleshooting
 
 ### Tool not found after installation
+
 - Linux: Check `~/.cargo/bin` is in PATH
 - macOS: Check `/opt/homebrew/bin` is in PATH
 - Restart shell: `exec fish` or `exec bash`
 
 ### Duplicate installations
+
 - This strategy prevents duplicates by using package managers for core tools
 - Rust-specific enhancements go via cargo
 - No tool should be installed in both roles
 
 ### Update tools
+
 - **Linux**: `sudo apt update && sudo apt upgrade` + `rustup update && cargo install-update -a`
 - **macOS**: `brew update && brew upgrade` + `rustup update && cargo install-update -a`

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -14,6 +14,7 @@ enable_shell_environment: true
 enable_development_tools: true
 enable_docker: true
 enable_hugo: true
+enable_herdr: true
 enable_tailscale: false
 enable_laptop_health_monitoring: false
 enable_laptop_lid_ignore: false

--- a/playbooks/base-environment.yml
+++ b/playbooks/base-environment.yml
@@ -122,6 +122,9 @@
     - role: tmux
       when: enable_development_tools | bool
       tags: [dev, tmux]
+    - role: herdr
+      when: enable_herdr | bool
+      tags: [dev, herdr]
     - role: neovim-latest
       when: enable_development_tools | bool
       tags: [dev, neovim, editor]
@@ -163,6 +166,7 @@
           - Server hardening: {{ enable_server_hardening }}
           - Hugo: {{ enable_hugo }}
           - Docker: {{ enable_docker }}
+          - herdr: {{ enable_herdr }}
           - Tailscale: {{ enable_tailscale }}
           - Laptop health monitoring: {{ enable_laptop_health_monitoring }}
 
@@ -180,6 +184,7 @@
           ✓ Database tools (PostgreSQL client, pgcli)
           ✓ Development folder structure
           ✓ tmux compiled from latest source
+          {% if enable_herdr | bool %}✓ herdr terminal workspace manager (prefix ctrl+a, bottom tab bar){% endif %}
           ✓ Neovim {{ neovim_version | default('latest') }} with vim symlink
           ✓ tree-sitter CLI for syntax highlighting
           ✓ Custom Neovim configuration from git@github.com:stonecharioteer/nvim-config.git
@@ -191,6 +196,7 @@
           1. Log out and log back in for shell/group changes
           2. Test development environment:
              - tmux new-session -d -s test
+             - herdr --version
              - docker run hello-world
              - nvim --version
              - mise list (verify language runtimes)
@@ -199,7 +205,7 @@
 
           🎯 Your base development environment is ready!
           - Modern shell: Fish with mise for language management
-          - Development tools: tmux, Neovim/AstroNvim, Docker
+          - Development tools: tmux, herdr, Neovim/AstroNvim, Docker
           - All CLI tools integrated and configured for productivity
 
           💡 Useful follow-ups:

--- a/playbooks/gui-environment.yml
+++ b/playbooks/gui-environment.yml
@@ -123,6 +123,9 @@
     - role: tmux
       when: enable_development_tools | bool
       tags: [dev, tmux]
+    - role: herdr
+      when: enable_herdr | bool
+      tags: [dev, herdr]
     - role: neovim-latest
       when: enable_development_tools | bool
       tags: [dev, neovim, editor]
@@ -182,6 +185,7 @@
           - Shell environment: {{ enable_shell_environment }}
           - Development tools: {{ enable_development_tools }}
           - Docker: {{ enable_docker }}
+          - herdr: {{ enable_herdr }}
           - GUI environment: {{ enable_gui_environment }}
           - Qtile: {{ enable_qtile }}
           - Nerd Fonts: {{ enable_nerd_fonts }}
@@ -202,6 +206,7 @@
           ✓ Modern CLI tools (ripgrep, fd, fzf, starship, etc.)
           ✓ Development folder structure
           ✓ tmux compiled from latest source
+          {% if enable_herdr | bool %}✓ herdr terminal workspace manager (prefix ctrl+a, bottom tab bar){% endif %}
           ✓ Neovim {{ neovim_version | default('latest') }} with vim symlink
           ✓ tree-sitter CLI for syntax highlighting
           ✓ Custom Neovim configuration from git@github.com:stonecharioteer/nvim-config.git
@@ -222,12 +227,13 @@
           3. Log in with your user account
           4. Test complete environment:
              - tmux new-session -d -s test
+             - herdr --version
              - docker run hello-world
              - nvim (complete plugin setup)
              - mise list (verify language runtimes)
 
           🎯 Your complete GUI workstation is ready!
           - Modern shell: Fish with mise for language management
-          - Development tools: tmux, Neovim/AstroNvim, Docker
+          - Development tools: tmux, herdr, Neovim/AstroNvim, Docker
           - GUI desktop: Qtile window manager with Alacritty terminal
           - All tools integrated and configured for maximum productivity

--- a/playbooks/macos-base-environment.yml
+++ b/playbooks/macos-base-environment.yml
@@ -11,6 +11,7 @@
     enable_development_tools: true
     enable_hugo: true
     enable_docker: true
+    enable_herdr: true
 
   pre_tasks:
     - name: Verify running on macOS
@@ -87,6 +88,9 @@
     - role: tmux
       when: enable_development_tools | bool
       tags: [dev, tmux]
+    - role: herdr
+      when: enable_herdr | bool
+      tags: [dev, herdr]
     - role: neovim-latest
       when: enable_development_tools | bool
       tags: [dev, neovim, editor]
@@ -115,6 +119,7 @@
           - Development tools: {{ enable_development_tools }}
           - Hugo: {{ enable_hugo }}
           - Docker: {{ enable_docker }}
+          - herdr: {{ enable_herdr }}
 
           ⚠️  IMPORTANT: Some tasks required sudo access:
           - Adding Fish to /etc/shells
@@ -135,6 +140,7 @@
           ✓ Database tools (PostgreSQL client, pgcli)
           ✓ Development folder structure
           ✓ tmux via Homebrew
+          {% if enable_herdr | bool %}✓ herdr terminal workspace manager (prefix ctrl+a, bottom tab bar){% endif %}
           ✓ Neovim via Homebrew with vim symlink
           ✓ tree-sitter CLI for syntax highlighting
           ✓ Custom Neovim configuration from git@github.com:stonecharioteer/nvim-config.git
@@ -146,6 +152,7 @@
           2. Launch Docker Desktop from Applications
           3. Test development environment:
              - tmux new-session -d -s test
+             - herdr --version
              - docker run hello-world (after launching Docker Desktop)
              - nvim --version
              - mise list (verify language runtimes)
@@ -154,7 +161,7 @@
 
           🎯 Your macOS base development environment is ready!
           - Modern shell: Fish with mise for language management
-          - Development tools: tmux, Neovim, Docker
+          - Development tools: tmux, herdr, Neovim, Docker
           - All CLI tools integrated and configured for productivity
 
           💡 For GUI enhancements, also run:

--- a/playbooks/macos-gui-environment.yml
+++ b/playbooks/macos-gui-environment.yml
@@ -10,6 +10,7 @@
     enable_shell_environment: true
     enable_development_tools: true
     enable_docker: true
+    enable_herdr: true
     enable_gui_environment: true
     enable_nerd_fonts: true
     enable_ghostty: true
@@ -88,6 +89,9 @@
     - role: tmux
       when: enable_development_tools | bool
       tags: [dev, tmux]
+    - role: herdr
+      when: enable_herdr | bool
+      tags: [dev, herdr]
     - role: neovim-latest
       when: enable_development_tools | bool
       tags: [dev, neovim, editor]
@@ -123,6 +127,7 @@
           - Shell environment: {{ enable_shell_environment }}
           - Development tools: {{ enable_development_tools }}
           - Docker: {{ enable_docker }}
+          - herdr: {{ enable_herdr }}
           - GUI environment: {{ enable_gui_environment }}
           - Nerd Fonts: {{ enable_nerd_fonts }}
           - Ghostty: {{ enable_ghostty }}
@@ -147,6 +152,7 @@
           ✓ Database tools (PostgreSQL client, pgcli)
           ✓ Development folder structure
           ✓ tmux via Homebrew
+          {% if enable_herdr | bool %}✓ herdr terminal workspace manager (prefix ctrl+a, bottom tab bar){% endif %}
           ✓ Neovim via Homebrew with vim symlink
           ✓ tree-sitter CLI for syntax highlighting
           ✓ Custom Neovim configuration from git@github.com:stonecharioteer/nvim-config.git
@@ -164,6 +170,7 @@
           4. Launch Ghostty terminal emulator
           5. Test complete environment:
              - tmux new-session -d -s test
+             - herdr --version
              - docker run hello-world (after launching Docker Desktop)
              - nvim (complete plugin setup)
              - mise list (verify language runtimes)
@@ -171,7 +178,7 @@
 
           🎯 Your complete macOS GUI workstation is ready!
           - Modern shell: Fish with mise for language management
-          - Development tools: tmux, Neovim, Docker
+          - Development tools: tmux, herdr, Neovim, Docker
           - GUI applications: Ghostty terminal, AeroSpace window manager
           - All tools integrated and configured for maximum productivity
 

--- a/roles/herdr/defaults/main.yml
+++ b/roles/herdr/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Default variables for herdr
+dev_user: "{{ ansible_user | default('stonecharioteer') }}"
+dev_home: "/home/{{ dev_user }}"
+herdr_user_group: "{{ 'staff' if ansible_facts['os_family'] == 'Darwin' else dev_user }}"
+
+herdr_install_dir: "{{ dev_home }}/.local/bin"
+herdr_binary_path: "{{ herdr_install_dir }}/herdr"
+herdr_config_dir: "{{ dev_home }}/.config/herdr"
+herdr_config_path: "{{ herdr_config_dir }}/config.toml"
+herdr_status_script_path: "{{ herdr_config_dir }}/status.sh"
+herdr_fish_data_dir: "{{ dev_home }}/.local/share/fish"
+herdr_fish_completions_path: "{{ herdr_fish_data_dir }}/vendor_completions.d/herdr.fish"
+herdr_fish_path_snippet: "{{ herdr_fish_data_dir }}/vendor_conf.d/herdr-path.fish"
+
+# Always install the public stable release from herdr.dev/latest.json.
+# Pinning is not used because older manifest entries do not always include checksums.
+herdr_manifest_url: "https://herdr.dev/latest.json"

--- a/roles/herdr/files/config.toml
+++ b/roles/herdr/files/config.toml
@@ -1,0 +1,19 @@
+# herdr configuration
+# Prefix matches tmux C-a muscle memory.
+
+[keys]
+prefix = "ctrl+a"
+
+[ui.toast]
+delivery = "system"
+
+[ui]
+show_agent_labels_on_pane_borders = true
+tab_bar_position = "bottom"
+tab_bar_right = [
+  { type = "zoom" },
+  { type = "hostname" },
+  { type = "datetime", format = "%H:%M" },
+  { type = "command", command = "~/.config/herdr/status.sh", interval_seconds = 5, timeout_seconds = 2 },
+]
+tab_bar_right_separator = " · "

--- a/roles/herdr/files/herdr-path.fish
+++ b/roles/herdr/files/herdr-path.fish
@@ -1,0 +1,4 @@
+# Managed by the distributed-dotfiles herdr role.
+# Keep the official herdr install dir on PATH without editing the git-managed
+# fish config repository.
+fish_add_path $HOME/.local/bin

--- a/roles/herdr/files/status.sh
+++ b/roles/herdr/files/status.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Compact right-status for herdr. Print one short line. No chevrons.
+# Portable across macOS and Linux. Battery output is omitted on machines
+# without a battery.
+
+load=""
+if [ -r /proc/loadavg ]; then
+  load=$(awk '{ print $1 }' /proc/loadavg)
+elif command -v sysctl >/dev/null 2>&1; then
+  load=$(sysctl -n vm.loadavg 2>/dev/null | awk '{ print $2 }')
+fi
+if [ -z "${load}" ]; then
+  load=$(uptime | awk -F'load averages?: |load average: ' '{ print $2 }' | awk -F, '{ print $1 }' | tr -d ' ')
+fi
+
+batt=""
+
+if command -v pmset >/dev/null 2>&1; then
+  batt_line=$(pmset -g batt 2>/dev/null | awk '/InternalBattery/ { print $0 }')
+  if [ -n "${batt_line}" ]; then
+    pct=$(printf '%s\n' "${batt_line}" | awk -F'\t' '{ print $2 }' | awk -F';' '{ print $1 }' | tr -d ' ')
+    state=$(printf '%s\n' "${batt_line}" | awk -F';' '{ print $2 }' | sed 's/^ *//;s/ *$//')
+    case "${state}" in
+      charged|charged*) icon="AC" ;;
+      charging|charging*) icon="CHG" ;;
+      discharging|discharging*) icon="BAT" ;;
+      *) icon="BAT" ;;
+    esac
+    batt="${icon} ${pct}"
+  fi
+fi
+
+if [ -z "${batt}" ]; then
+  for bat in /sys/class/power_supply/BAT*; do
+    [ -d "${bat}" ] || continue
+    cap=""
+    status=""
+    if [ -r "${bat}/capacity" ]; then
+      cap=$(tr -d '\n' < "${bat}/capacity")
+    fi
+    if [ -r "${bat}/status" ]; then
+      status=$(tr -d '\n' < "${bat}/status")
+    fi
+    if [ -n "${cap}" ]; then
+      case "${status}" in
+        Full) icon="AC" ;;
+        Charging) icon="CHG" ;;
+        Discharging) icon="BAT" ;;
+        *) icon="BAT" ;;
+      esac
+      batt="${icon} ${cap}%"
+      break
+    fi
+  done
+fi
+
+if [ -n "${batt}" ]; then
+  printf 'L %s | %s\n' "${load}" "${batt}"
+else
+  printf 'L %s\n' "${load}"
+fi

--- a/roles/herdr/handlers/main.yml
+++ b/roles/herdr/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload herdr config
+  command: "{{ herdr_binary_path }} server reload-config"
+  failed_when: false
+  become: no

--- a/roles/herdr/tasks/main.yml
+++ b/roles/herdr/tasks/main.yml
@@ -1,0 +1,185 @@
+---
+# Install herdr from the public stable manifest and apply the shared config.
+# The official curl | sh installer is not used here. The role downloads the
+# matching GitHub release asset and verifies its SHA-256 checksum.
+
+- name: Ensure herdr directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ dev_user }}"
+    group: "{{ herdr_user_group }}"
+    mode: "0755"
+  loop:
+    - "{{ herdr_install_dir }}"
+    - "{{ herdr_config_dir }}"
+    - "{{ herdr_fish_completions_path | dirname }}"
+    - "{{ herdr_fish_path_snippet | dirname }}"
+  become: no
+
+- name: Fetch herdr release manifest
+  uri:
+    url: "{{ herdr_manifest_url }}"
+    return_content: yes
+    status_code: 200
+  register: herdr_manifest
+  check_mode: false
+  become: no
+
+- name: Set herdr release facts
+  set_fact:
+    herdr_release: "{{ herdr_manifest.json | default((herdr_manifest.content | default('{}') | from_json), true) }}"
+    herdr_os_name: "{{ 'macos' if ansible_facts['os_family'] == 'Darwin' else 'linux' }}"
+    herdr_cpu_name: "{{ 'aarch64' if (ansible_facts['architecture'] | default(ansible_facts['machine']) | default('')) in ['arm64', 'aarch64'] else 'x86_64' }}"
+
+- name: Set herdr asset key
+  set_fact:
+    herdr_asset_key: "{{ herdr_os_name }}-{{ herdr_cpu_name }}"
+
+- name: Fail when herdr has no binary for this platform
+  fail:
+    msg: >-
+      herdr has no release asset for {{ herdr_asset_key }}
+      (os_family={{ ansible_facts['os_family'] }},
+      architecture={{ ansible_facts['architecture'] }}).
+  when: herdr_asset_key not in (herdr_release.assets | default({}))
+
+- name: Set herdr download facts
+  set_fact:
+    herdr_target_version: "{{ herdr_release.version }}"
+    herdr_download_url: "{{ herdr_release.assets[herdr_asset_key] }}"
+    herdr_sha256: "{{ herdr_release.sha256[herdr_asset_key] | default('') }}"
+
+- name: Fail when herdr checksum is missing
+  fail:
+    msg: "herdr release manifest has no SHA-256 checksum for {{ herdr_asset_key }}."
+  when: herdr_sha256 | length != 64
+
+- name: Check installed herdr version
+  shell: command -v "{{ herdr_binary_path }}" >/dev/null 2>&1 && "{{ herdr_binary_path }}" --version
+  args:
+    executable: /bin/bash
+  register: herdr_installed
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  become: no
+
+- name: Set installed herdr version
+  set_fact:
+    herdr_installed_version: "{{ herdr_installed.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') | default('', true) }}"
+
+- name: Determine whether herdr should be installed or upgraded
+  set_fact:
+    herdr_needs_install: "{{ (herdr_installed.rc | default(1)) != 0 or herdr_installed_version != (herdr_target_version | string) }}"
+
+- name: Display herdr installation status
+  debug:
+    msg: |
+      herdr status:
+      Binary path: {{ herdr_binary_path }}
+      Installed: {{ herdr_installed.stdout | default('not installed') }}
+      Target version: {{ herdr_target_version }}
+      Asset: {{ herdr_asset_key }}
+      Needs install/upgrade: {{ herdr_needs_install }}
+
+- name: Install herdr {{ herdr_target_version }}
+  when: herdr_needs_install | bool
+  become: no
+  block:
+    - name: Download herdr {{ herdr_target_version }}
+      get_url:
+        url: "{{ herdr_download_url }}"
+        dest: "{{ herdr_binary_path }}.new"
+        checksum: "sha256:{{ herdr_sha256 }}"
+        mode: "0755"
+        force: yes
+        owner: "{{ dev_user }}"
+        group: "{{ herdr_user_group }}"
+
+    - name: Replace herdr binary
+      command: mv "{{ herdr_binary_path }}.new" "{{ herdr_binary_path }}"
+  rescue:
+    - name: Remove incomplete herdr download
+      file:
+        path: "{{ herdr_binary_path }}.new"
+        state: absent
+      failed_when: false
+
+    - name: Fail herdr installation
+      fail:
+        msg: "herdr installation failed for {{ herdr_asset_key }} {{ herdr_target_version }}."
+
+- name: Install herdr config
+  copy:
+    src: config.toml
+    dest: "{{ herdr_config_path }}"
+    owner: "{{ dev_user }}"
+    group: "{{ herdr_user_group }}"
+    mode: "0644"
+  become: no
+  notify: Reload herdr config
+
+- name: Install herdr status script
+  copy:
+    src: status.sh
+    dest: "{{ herdr_status_script_path }}"
+    owner: "{{ dev_user }}"
+    group: "{{ herdr_user_group }}"
+    mode: "0755"
+  become: no
+
+- name: Install herdr PATH helper for fish
+  copy:
+    src: herdr-path.fish
+    dest: "{{ herdr_fish_path_snippet }}"
+    owner: "{{ dev_user }}"
+    group: "{{ herdr_user_group }}"
+    mode: "0644"
+  become: no
+
+- name: Generate herdr fish completions
+  command: "{{ herdr_binary_path }} completion fish"
+  register: herdr_fish_completion
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  become: no
+
+- name: Install herdr fish completions
+  copy:
+    dest: "{{ herdr_fish_completions_path }}"
+    content: "{{ herdr_fish_completion.stdout | trim }}\n"
+    owner: "{{ dev_user }}"
+    group: "{{ herdr_user_group }}"
+    mode: "0644"
+  become: no
+  when: (herdr_fish_completion.rc | default(1)) == 0
+
+- name: Verify herdr installation
+  shell: command -v "{{ herdr_binary_path }}" >/dev/null 2>&1 && "{{ herdr_binary_path }}" --version
+  args:
+    executable: /bin/bash
+  register: herdr_verify
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  become: no
+
+- name: Display herdr setup result
+  debug:
+    msg: |
+      herdr is installed and configured.
+      Version: {{ herdr_verify.stdout }}
+      Binary: {{ herdr_binary_path }}
+      Config: {{ herdr_config_path }}
+      Status script: {{ herdr_status_script_path }}
+
+      Shared settings:
+      - prefix: ctrl+a
+      - tab bar: bottom
+      - toast delivery: system
+
+      Start a session with: herdr
+      Stop the background server with: herdr server stop
+      tmux stays installed as a fallback. Fish autostart for tmux is not managed in this repository.


### PR DESCRIPTION
## Summary
- Add a `herdr` role that installs the stable binary from herdr.dev with SHA-256 verification.
- Deploy the shared `ctrl+a` prefix, bottom tab bar, and portable status script.
- Enable herdr by default on Linux and macOS base/GUI playbooks.

## Notes
tmux login autostart is not managed in this repository. It lives in the fish config repo.

## Test plan
- [x] `ansible-playbook playbooks/macos-base-environment.yml --tags herdr --check --diff` on this Mac
- [x] playbook syntax checks for Linux and macOS base/GUI playbooks
- [ ] apply `--tags herdr` to a Linux host after merge